### PR TITLE
feat: APIレスポンスタイム計測とパフォーマンス最適化

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -55,6 +55,11 @@ model DailyReport {
   comments     Comment[]
 
   @@unique([salesId, reportDate])
+  @@index([salesId])
+  @@index([reportDate])
+  @@index([status])
+  @@index([salesId, status])
+  @@index([reportDate, status])
   @@map("daily_report")
 }
 
@@ -77,6 +82,9 @@ model VisitRecord {
   report   DailyReport @relation(fields: [reportId], references: [reportId], onDelete: Cascade)
   customer Customer    @relation(fields: [customerId], references: [customerId], onDelete: Restrict)
 
+  @@index([reportId])
+  @@index([customerId])
+  @@index([reportId, visitOrder])
   @@map("visit_record")
 }
 
@@ -95,6 +103,8 @@ model Customer {
   // Relations
   visitRecords VisitRecord[]
 
+  @@index([customerName])
+  @@index([companyName])
   @@map("customer")
 }
 
@@ -111,6 +121,9 @@ model Comment {
   report    DailyReport @relation(fields: [reportId], references: [reportId], onDelete: Cascade)
   commenter SalesStaff  @relation(fields: [commenterId], references: [salesId], onDelete: Cascade)
 
+  @@index([reportId])
+  @@index([commenterId])
+  @@index([reportId, createdAt])
   @@map("comment")
 }
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -8,6 +8,7 @@ import commentsRoutes from './routes/comments';
 import customersRoutes from './routes/customers';
 import statisticsRoutes from './routes/statistics';
 import salesStaffRoutes from './routes/salesStaff';
+import metricsRoutes from './routes/metrics';
 import { errorHandler, notFoundHandler } from './middlewares/errorHandler';
 import {
   helmetMiddleware,
@@ -15,11 +16,15 @@ import {
   additionalSecurityHeaders,
   sanitizeInput,
 } from './middlewares/security';
+import { responseTimeMiddleware } from './middlewares/responseTime';
 
 dotenv.config();
 
 const app = express();
 const PORT = process.env.PORT || 3001;
+
+// Response time measurement (must be first to measure accurately)
+app.use(responseTimeMiddleware);
 
 // Security Middleware
 app.use(helmetMiddleware);
@@ -52,6 +57,7 @@ app.use('/api/v1/reports/:reportId/comments', commentsRoutes);
 app.use('/api/v1/customers', customersRoutes);
 app.use('/api/v1/statistics', statisticsRoutes);
 app.use('/api/v1/sales-staff', salesStaffRoutes);
+app.use('/api/v1/metrics', metricsRoutes);
 
 // 404 handler - すべてのルートの後に配置
 app.use(notFoundHandler);

--- a/backend/src/middlewares/responseTime.ts
+++ b/backend/src/middlewares/responseTime.ts
@@ -1,0 +1,166 @@
+import { Request, Response, NextFunction } from 'express';
+
+/**
+ * レスポンスタイム計測ミドルウェア
+ * 各APIリクエストの処理時間を計測し、ログ出力とレスポンスヘッダーに追加
+ */
+
+// スロークエリの閾値（ミリ秒）
+const SLOW_THRESHOLD_MS = 1000;
+const WARNING_THRESHOLD_MS = 500;
+
+interface RequestMetrics {
+  path: string;
+  method: string;
+  statusCode: number;
+  responseTime: number;
+  timestamp: Date;
+}
+
+// メトリクス履歴（直近100件を保持）
+const metricsHistory: RequestMetrics[] = [];
+const MAX_HISTORY_SIZE = 100;
+
+/**
+ * レスポンスタイム計測ミドルウェア
+ */
+export function responseTimeMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const startTime = process.hrtime.bigint();
+  const startDate = new Date();
+
+  // レスポンス完了時のハンドラー
+  res.on('finish', () => {
+    const endTime = process.hrtime.bigint();
+    const durationNs = Number(endTime - startTime);
+    const durationMs = durationNs / 1_000_000;
+
+    // ヘッダーに追加（まだ送信されていない場合）
+    if (!res.headersSent) {
+      res.setHeader('X-Response-Time', `${durationMs.toFixed(2)}ms`);
+    }
+
+    // メトリクスを記録
+    const metrics: RequestMetrics = {
+      path: req.path,
+      method: req.method,
+      statusCode: res.statusCode,
+      responseTime: durationMs,
+      timestamp: startDate,
+    };
+
+    // 履歴に追加（古いものを削除）
+    metricsHistory.push(metrics);
+    if (metricsHistory.length > MAX_HISTORY_SIZE) {
+      metricsHistory.shift();
+    }
+
+    // ログ出力（開発環境または遅いリクエスト）
+    const logLevel = getLogLevel(durationMs);
+    if (process.env.NODE_ENV !== 'production' || logLevel !== 'normal') {
+      logRequest(metrics, logLevel);
+    }
+  });
+
+  next();
+}
+
+/**
+ * ログレベルを決定
+ */
+function getLogLevel(durationMs: number): 'slow' | 'warning' | 'normal' {
+  if (durationMs >= SLOW_THRESHOLD_MS) {
+    return 'slow';
+  }
+  if (durationMs >= WARNING_THRESHOLD_MS) {
+    return 'warning';
+  }
+  return 'normal';
+}
+
+/**
+ * リクエストをログ出力
+ */
+function logRequest(metrics: RequestMetrics, level: 'slow' | 'warning' | 'normal'): void {
+  const { method, path, statusCode, responseTime } = metrics;
+  const timeStr = responseTime.toFixed(2);
+
+  switch (level) {
+    case 'slow':
+      console.warn(`🐢 SLOW: ${method} ${path} - ${statusCode} - ${timeStr}ms`);
+      break;
+    case 'warning':
+      console.log(`⚠️  WARN: ${method} ${path} - ${statusCode} - ${timeStr}ms`);
+      break;
+    default:
+      console.log(`✅ ${method} ${path} - ${statusCode} - ${timeStr}ms`);
+  }
+}
+
+/**
+ * パフォーマンス統計を取得
+ */
+export function getPerformanceStats(): {
+  totalRequests: number;
+  averageResponseTime: number;
+  slowRequests: number;
+  warningRequests: number;
+  p50: number;
+  p95: number;
+  p99: number;
+  byEndpoint: Record<string, { count: number; avgTime: number; maxTime: number }>;
+} {
+  if (metricsHistory.length === 0) {
+    return {
+      totalRequests: 0,
+      averageResponseTime: 0,
+      slowRequests: 0,
+      warningRequests: 0,
+      p50: 0,
+      p95: 0,
+      p99: 0,
+      byEndpoint: {},
+    };
+  }
+
+  const times = metricsHistory.map((m) => m.responseTime).sort((a, b) => a - b);
+  const totalRequests = times.length;
+  const averageResponseTime = times.reduce((a, b) => a + b, 0) / totalRequests;
+  const slowRequests = times.filter((t) => t >= SLOW_THRESHOLD_MS).length;
+  const warningRequests = times.filter((t) => t >= WARNING_THRESHOLD_MS && t < SLOW_THRESHOLD_MS).length;
+
+  // パーセンタイル計算
+  const p50 = times[Math.floor(totalRequests * 0.5)] || 0;
+  const p95 = times[Math.floor(totalRequests * 0.95)] || 0;
+  const p99 = times[Math.floor(totalRequests * 0.99)] || 0;
+
+  // エンドポイント別統計
+  const byEndpoint: Record<string, { count: number; avgTime: number; maxTime: number }> = {};
+  for (const m of metricsHistory) {
+    const key = `${m.method} ${m.path}`;
+    if (!byEndpoint[key]) {
+      byEndpoint[key] = { count: 0, avgTime: 0, maxTime: 0 };
+    }
+    byEndpoint[key].count++;
+    byEndpoint[key].avgTime =
+      (byEndpoint[key].avgTime * (byEndpoint[key].count - 1) + m.responseTime) / byEndpoint[key].count;
+    byEndpoint[key].maxTime = Math.max(byEndpoint[key].maxTime, m.responseTime);
+  }
+
+  return {
+    totalRequests,
+    averageResponseTime,
+    slowRequests,
+    warningRequests,
+    p50,
+    p95,
+    p99,
+    byEndpoint,
+  };
+}
+
+/**
+ * メトリクス履歴をクリア
+ */
+export function clearMetricsHistory(): void {
+  metricsHistory.length = 0;
+}

--- a/backend/src/routes/metrics.ts
+++ b/backend/src/routes/metrics.ts
@@ -1,0 +1,65 @@
+import { Router, Request, Response } from 'express';
+import { getPerformanceStats, clearMetricsHistory } from '../middlewares/responseTime';
+import { authenticate, requireAdmin } from '../middlewares/auth';
+
+const router = Router();
+
+/**
+ * @swagger
+ * /api/v1/metrics/performance:
+ *   get:
+ *     summary: パフォーマンス統計を取得
+ *     tags: [Metrics]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: パフォーマンス統計
+ */
+router.get('/performance', authenticate, requireAdmin, (_req: Request, res: Response) => {
+  const stats = getPerformanceStats();
+  res.json({
+    success: true,
+    data: {
+      summary: {
+        totalRequests: stats.totalRequests,
+        averageResponseTime: `${stats.averageResponseTime.toFixed(2)}ms`,
+        slowRequests: stats.slowRequests,
+        warningRequests: stats.warningRequests,
+      },
+      percentiles: {
+        p50: `${stats.p50.toFixed(2)}ms`,
+        p95: `${stats.p95.toFixed(2)}ms`,
+        p99: `${stats.p99.toFixed(2)}ms`,
+      },
+      byEndpoint: Object.entries(stats.byEndpoint).map(([endpoint, data]) => ({
+        endpoint,
+        count: data.count,
+        avgTime: `${data.avgTime.toFixed(2)}ms`,
+        maxTime: `${data.maxTime.toFixed(2)}ms`,
+      })),
+    },
+  });
+});
+
+/**
+ * @swagger
+ * /api/v1/metrics/performance/clear:
+ *   post:
+ *     summary: パフォーマンス統計をクリア
+ *     tags: [Metrics]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: クリア成功
+ */
+router.post('/performance/clear', authenticate, requireAdmin, (_req: Request, res: Response) => {
+  clearMetricsHistory();
+  res.json({
+    success: true,
+    message: 'Performance metrics cleared',
+  });
+});
+
+export default router;


### PR DESCRIPTION
## Summary

- APIレスポンスタイム計測ミドルウェアを追加
- パフォーマンス統計エンドポイントを追加
- データベースインデックスを最適化

## Changes

### レスポンスタイム計測
- 全APIリクエストの処理時間を自動計測
- スロークエリ検出（500ms警告、1000ms遅延）
- X-Response-Timeヘッダーでクライアントに時間を通知

### パフォーマンス統計エンドポイント
- `GET /api/v1/metrics/performance` - 統計情報を取得（管理者のみ）
- `POST /api/v1/metrics/performance/clear` - 統計をクリア（管理者のみ）
- P50/P95/P99パーセンタイル統計
- エンドポイント別パフォーマンス分析

### データベースインデックス追加
- daily_report: salesId, reportDate, status, 複合インデックス
- visit_record: reportId, customerId, 複合インデックス
- comment: reportId, commenterId, 複合インデックス
- customer: customerName, companyName

## Test Plan

- [ ] `npm run dev`でバックエンドを起動
- [ ] 各APIにアクセスしてレスポンスタイムがログに出力されることを確認
- [ ] レスポンスヘッダーにX-Response-Timeが含まれることを確認
- [ ] `/api/v1/metrics/performance`でパフォーマンス統計が取得できることを確認
- [ ] マイグレーション実行後、インデックスが作成されることを確認

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)